### PR TITLE
Updating quickstart-geo-app roo scripts

### DIFF
--- a/quickstart-geo-app/log.roo
+++ b/quickstart-geo-app/log.roo
@@ -59,7 +59,7 @@ web mvc jquery setup
 web mvc datatables setup
 web mvc jquery all
 web mvc bootstrap setup
-web mvc datatables add --type ~.web.VetController --mode show
+web mvc datatables add --type ~.web.VetController
 web mvc datatables add --type ~.web.VetListController
 web mvc datatables add --type ~.web.PetController
 web mvc datatables add --type ~.web.OwnerController

--- a/quickstart-geo-app/quickstart-geo.roo
+++ b/quickstart-geo-app/quickstart-geo.roo
@@ -81,7 +81,7 @@ web mvc jquery all
 web mvc bootstrap setup
 
 // Creating master patterns
-web mvc datatables add --type ~.web.VetController --mode show
+web mvc datatables add --type ~.web.VetController
 web mvc datatables add --type ~.web.VetListController
 web mvc datatables add --type ~.web.PetController
 web mvc datatables add --type ~.web.OwnerController


### PR DESCRIPTION
Update for fixing the roo scripts. Adding datatables to Visits with "mode show" causes bug in Visits' loupefield in Pets list. Now gvnix consoles warning about this and stops execution, so I've removed mode show for Visits' datatables in the scripts.